### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/services/reis/rei_s/utils.py
+++ b/services/reis/rei_s/utils.py
@@ -11,7 +11,11 @@ from rei_s.prometheus_server import PrometheusHttpServer
 
 
 def get_uploaded_file_path(file_id: str):
-    return os.path.join(tempfile.gettempdir(), file_id)
+    joined_path = os.path.join(tempfile.gettempdir(), file_id)
+    normalized_path = os.path.normpath(joined_path)
+    if not normalized_path.startswith(tempfile.gettempdir()):
+        raise ValueError("Invalid file path")
+    return normalized_path
 
 
 async def startup_workers(app: FastAPI, workers: int):

--- a/services/reis/tests/unit/tmp_file_permission_test.py
+++ b/services/reis/tests/unit/tmp_file_permission_test.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from langchain_community.embeddings import FakeEmbeddings
 from rei_s.config import update_tempdir
 from rei_s.services.stores.devnull_store import DevNullStoreAdapter
+from rei_s.utils import get_uploaded_file_path
 from tests.unit.utils import env_value
 
 
@@ -59,3 +60,8 @@ def test_add_files_read_only(mocker, app, use_unknown_tmp_dir):
                 },
             )
         assert response.status_code == 500
+
+def test_path_traversal_attack():
+    # Test path traversal prevention
+    with pytest.raises(ValueError, match="Invalid file path"):
+        get_uploaded_file_path("../../../etc/passwd")


### PR DESCRIPTION
Potential fix for [https://github.com/codecentric/c4-genai-suite/security/code-scanning/6](https://github.com/codecentric/c4-genai-suite/security/code-scanning/6)

To fix the issue, we need to validate the `file_id` before constructing the `dest_path`. This can be achieved by ensuring that the resulting path is contained within a safe root directory. Specifically:
1. Use `os.path.normpath` to normalize the path and remove any `..` segments.
2. Check that the normalized path starts with a predefined safe root directory.
3. Raise an exception if the validation fails.

Additionally, we can use `werkzeug.utils.secure_filename` to sanitize the `file_id` to ensure it does not contain special characters or unsafe patterns.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
