### PR TITLE
Potential fix for code scanning alert no. 3: Disabling certificate validation

### DIFF
--- a/backend/src/extensions/tools/open-api.ts
+++ b/backend/src/extensions/tools/open-api.ts
@@ -111,7 +111,7 @@ export class OpenApiExtension implements Extension {
         headers,
         fetchApi: async (request, init) => {
           const agent = new https.Agent({
-            rejectUnauthorized: false,
+            // Default behavior: certificates are validated
           });
 
           // This method is only called from the generated API-Clients with hardcoded


### PR DESCRIPTION
Potential fix for [https://github.com/codecentric/c4-genai-suite/security/code-scanning/3](https://github.com/codecentric/c4-genai-suite/security/code-scanning/3)

To fix the issue, the `rejectUnauthorized` option should be set to its default value (`true`) or omitted entirely, as the default behavior of the `https.Agent` is to validate certificates. This ensures that the application verifies the authenticity of the server it is communicating with, preventing man-in-the-middle attacks.

The fix involves modifying the `https.Agent` configuration on line 114 to remove the `rejectUnauthorized: false` option. No additional imports or dependencies are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
