### PR TITLE
ci: use `pull_request` trigger instead of `push` trigger

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -3,14 +3,10 @@ permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/backend.yaml
       - backend/**
-    branches:
-      - '**'
-    tags-ignore:
-      - "**"
   workflow_call:
 
 defaults:

--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -2,7 +2,7 @@ name: Build Container images
 
 # this workflow will be triggered manually from workflows needing the images
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/build-container-images.yaml
   workflow_call:

--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -2,6 +2,11 @@ name: Build Container images
 
 # this workflow will be triggered manually from workflows needing the images
 on:
+  push:
+    branches:
+      - 'main'
+    tags-ignore:
+      - "**"
   pull_request:
     paths:
       - .github/workflows/build-container-images.yaml

--- a/.github/workflows/build-dev-helper-container-images.yaml
+++ b/.github/workflows/build-dev-helper-container-images.yaml
@@ -1,6 +1,6 @@
 name: Build Dev Helper Container Images
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/build-dev-helper-container-images.yaml
       - /dev

--- a/.github/workflows/e2e-complete.yaml
+++ b/.github/workflows/e2e-complete.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_call:
   workflow_dispatch:
-  push:
+  pull_request:
     paths:
       - .github/workflows/e2e-complete.yaml
   schedule:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,7 @@ permissions:
   packages: write
 
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/e2e.yaml
       - .github/workflows/e2e-template.yaml
@@ -13,10 +13,6 @@ on:
       - backend/**
       - services/reis/**
       - dev/caddy-gateway-proxy/**
-    branches:
-      - '**'
-    tags-ignore:
-      - "**"
   workflow_call:
 
 defaults:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -3,14 +3,10 @@ permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/frontend.yaml
       - frontend/**
-    branches:
-      - '**'
-    tags-ignore:
-      - "**"
   workflow_call:
 
 defaults:

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -3,14 +3,10 @@ permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/helm-chart.yaml
       - helm-chart/**
-    branches:
-      - '**'
-    tags-ignore:
-      - "**"
   workflow_call:
 
 jobs:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,6 @@ on:
   push:
     tags:
       - v*
-      - test-workflow* # TODO remove after testing this workflow has concluded
 
 jobs:
   backend:

--- a/.github/workflows/reis.yaml
+++ b/.github/workflows/reis.yaml
@@ -3,14 +3,10 @@ permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/reis.yaml
       - services/reis/**
-    branches:
-      - '**'
-    tags-ignore:
-      - "**"
   workflow_call:
 
 defaults:


### PR DESCRIPTION
The scenario:
Commit 1 changes logic in the backend. It starts the backend tests, which fail.
Commit 2 changes a typo in the main readme. Since the push does not contain changes to the backend folder, no tests are started.
The pull request only shows the checks triggered by the last commit, which are all successful. The unsuccessful tests of previous commits are ignored.

So, in this scenario we could merge despite of failing tests.

To fix this, we change the trigger from `push` to `pull_request`, which will always trigger all jobs which are affected by the whole PR, everytime the PR changes (e.g. by a push to the corresponding branch).