### PR TITLE
feat: allow switching of assistants after the first message

### DIFF
--- a/backend/backend-dev-spec.json
+++ b/backend/backend-dev-spec.json
@@ -1703,6 +1703,7 @@
         "type": "object",
         "properties": {
           "id": { "type": "number", "description": "The ID of the message." },
+          "configurationId": { "type": "number", "description": "The ID of the used configuration." },
           "content": {
             "type": "array",
             "description": "The content.",
@@ -1736,7 +1737,7 @@
           },
           "logging": { "description": "The logging information.", "type": "array", "items": { "type": "string" } }
         },
-        "required": ["id", "content", "type"]
+        "required": ["id", "configurationId", "content", "type"]
       },
       "MessagesDto": {
         "type": "object",

--- a/backend/src/controllers/conversations/conversations.e2e.spec.ts
+++ b/backend/src/controllers/conversations/conversations.e2e.spec.ts
@@ -107,7 +107,7 @@ async function seedTestData(dataSource: DataSource) {
   const conversation = await createConversationEntity(conversationRepository, configurationEntity, userEntity);
   const bucketEntity = await createBucket(bucketRepository);
   await createFiles(fileRepository, conversation.id, bucketEntity);
-  await createMessages(messageRepository, conversation.id);
+  await createMessages(messageRepository, conversation.id, configurationEntity.id);
 
   return conversation;
 }
@@ -142,10 +142,15 @@ function createConversationEntity(
   return conversationRepository.save(conversationEntity);
 }
 
-function createMessages(messageRepository: Repository<MessageEntity>, conversationId: number): Promise<MessageEntity[]> {
+function createMessages(
+  messageRepository: Repository<MessageEntity>,
+  conversationId: number,
+  configurationId: number,
+): Promise<MessageEntity[]> {
   const messages = [];
   const message1 = new MessageEntity();
   message1.conversationId = conversationId;
+  message1.configurationId = configurationId;
   message1.createdAt = new Date();
   message1.type = 'human';
   message1.data = `{"content":"hi","additional_kwargs":{},"response_metadata":{}}`;
@@ -153,6 +158,7 @@ function createMessages(messageRepository: Repository<MessageEntity>, conversati
 
   const message2 = new MessageEntity();
   message2.conversationId = conversationId;
+  message2.configurationId = configurationId;
   message2.createdAt = new Date();
   message2.type = 'ai';
   message2.data = `{"content":"Hello! How can I assist you today?","tool_calls":[],"invalid_tool_calls":[],"additional_kwargs":{},"response_metadata":{}}`;

--- a/backend/src/controllers/conversations/dtos/index.ts
+++ b/backend/src/controllers/conversations/dtos/index.ts
@@ -56,6 +56,12 @@ export class MessageDto {
   id!: number;
 
   @ApiProperty({
+    description: 'The ID of the used configuration.',
+    required: true,
+  })
+  configurationId!: number;
+
+  @ApiProperty({
     description: 'The content.',
     required: true,
     type: 'array',
@@ -116,6 +122,7 @@ export class MessageDto {
     result.tools = source.tools;
     result.type = source.type;
     result.logging = source.logging;
+    result.configurationId = source.configurationId;
 
     return result;
   }

--- a/backend/src/controllers/files/files.e2e.spec.ts
+++ b/backend/src/controllers/files/files.e2e.spec.ts
@@ -264,6 +264,7 @@ function createMessageEntity(repository: Repository<MessageEntity>) {
   const entity = new MessageEntity();
   entity.id = 1;
   entity.conversationId = 1;
+  entity.configurationId = 1;
   entity.data = { content: 'empty' };
   entity.type = 'ai';
   entity.sources = [

--- a/backend/src/controllers/usages/usages.e2e.spec.ts
+++ b/backend/src/controllers/usages/usages.e2e.spec.ts
@@ -162,14 +162,14 @@ async function seedTestData(dataSource: DataSource) {
   for (const userEntity of userEntities) {
     const conversationEntity = await createConversationEntity(userEntity.id, configurationEntity.id, conversationRepository);
 
-    await createMessageEntity(conversationEntity.id, now, messagesRepository);
+    await createMessageEntity(conversationEntity.id, configurationEntity.id, now, messagesRepository);
     await createUsageEntity(now, userEntity, usageRepository);
   }
 
   // two users send a message last month
   for (let i = 0; i < userEntities.length - 1; i++) {
     const conversationEntity = await createConversationEntity(userEntities[i].id, configurationEntity.id, conversationRepository);
-    await createMessageEntity(conversationEntity.id, startOfMonth(subMonths(now, 1)), messagesRepository);
+    await createMessageEntity(conversationEntity.id, configurationEntity.id, startOfMonth(subMonths(now, 1)), messagesRepository);
   }
 
   const configurations = await configurationRepository.find();
@@ -224,11 +224,13 @@ async function createConversationEntity(
 
 async function createMessageEntity(
   conversationId: number,
+  configurationId: number,
   creationDate: Date,
   messageRepository: Repository<MessageEntity>,
 ): Promise<MessageEntity> {
   const messageEntity = new MessageEntity();
   messageEntity.conversationId = conversationId;
+  messageEntity.configurationId = configurationId;
   messageEntity.createdAt = creationDate;
   messageEntity.type = 'text';
   messageEntity.type = 'human';

--- a/backend/src/domain/chat/interfaces.ts
+++ b/backend/src/domain/chat/interfaces.ts
@@ -175,6 +175,8 @@ export interface Message {
   rating?: MessageRating;
 
   logging?: string[];
+
+  configurationId: number;
 }
 
 export type NormalizedMessageContentText = {

--- a/backend/src/domain/chat/use-cases/get-history.ts
+++ b/backend/src/domain/chat/use-cases/get-history.ts
@@ -43,7 +43,7 @@ export class GetHistoryHandler implements IQueryHandler<GetHistory, GetHistoryRe
 
     const entities = await this.messages.getMessageThread(conversationId);
 
-    const result = entities.map((m: { id: number; type: string; data: MessageEntityData }) => ({
+    const result = entities.map((m: { id: number; configurationId: number; type: string; data: MessageEntityData }) => ({
       ...m,
       type: m.type as MessageType,
       content: normalizedMessageContent(m.data.content),

--- a/backend/src/domain/chat/use-cases/update-conversation.ts
+++ b/backend/src/domain/chat/use-cases/update-conversation.ts
@@ -59,12 +59,6 @@ export class UpdateConversationHandler implements ICommandHandler<UpdateConversa
       if (!configuration.enabled) {
         throw new BadRequestException('Configuration is not enabled.');
       }
-
-      const totalMessages = await this.messages.countBy({ conversationId: id });
-
-      if (totalMessages > 0) {
-        throw new BadRequestException('Configuration ID cannot be changed after the conversation has been started.');
-      }
     }
 
     if (context) {

--- a/backend/src/domain/database/entities/message.ts
+++ b/backend/src/domain/database/entities/message.ts
@@ -1,6 +1,16 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Source } from 'src/domain/chat';
 import { schema } from '../typeorm.helper';
+import { ConfigurationEntity } from './configuration';
 import { ConversationEntity } from './conversation';
 
 export type ExtensionSource = Source & { extensionExternalId: string };
@@ -24,6 +34,13 @@ export class MessageEntity {
 
   @Column('simple-json', { nullable: true })
   tools?: any;
+
+  @Column()
+  configurationId!: number;
+
+  @ManyToOne(() => ConfigurationEntity)
+  @JoinColumn({ name: 'configurationId' })
+  configuration!: ConfigurationEntity;
 
   @Column('simple-json', { nullable: true })
   debug?: any;

--- a/backend/src/migrations/1754379840682-addConfigurationIdToMessages.ts
+++ b/backend/src/migrations/1754379840682-addConfigurationIdToMessages.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddConfigurationIdToMessages1754379840682 implements MigrationInterface {
+  name = 'AddConfigurationIdToMessages1754379840682';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "company_chat"."messages" ADD "configurationId" integer`);
+
+    await queryRunner.query(`
+        UPDATE "company_chat"."messages" m
+        SET "configurationId" = (
+            SELECT "configurationId"
+            FROM "company_chat"."conversations" c
+            WHERE c."id" = m."conversationId"
+        )
+    `);
+
+    await queryRunner.query(`ALTER TABLE "company_chat"."messages" ALTER COLUMN "configurationId" SET NOT NULL`);
+
+    await queryRunner.query(
+      `ALTER TABLE "company_chat"."messages" ADD CONSTRAINT "FK_30684080549b7e451cd571009d7" FOREIGN KEY ("configurationId") REFERENCES "company_chat"."configurations"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "company_chat"."messages" DROP CONSTRAINT "FK_30684080549b7e451cd571009d7"`);
+    await queryRunner.query(`ALTER TABLE "company_chat"."messages" DROP COLUMN "configurationId"`);
+  }
+}

--- a/e2e/extension-tests/azure-open-ai-assistant-change.spec.ts
+++ b/e2e/extension-tests/azure-open-ai-assistant-change.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+import { config } from '../tests/utils/config';
+import {
+  addAzureModelToConfiguration,
+  addSystemPromptToConfiguration,
+  cleanup,
+  createConfiguration,
+  enterAdminArea,
+  enterUserArea,
+  login,
+  newChat,
+  selectConfiguration,
+  sendMessage,
+} from '../tests/utils/helper';
+
+if (!config.AZURE_OPEN_AI_API_KEY) {
+  test.skip('should configure Azure OpenAI-Open AI LLM for chats [skipped due to missing API_KEY in env]', () => {});
+} else {
+  test('chat', async ({ page }) => {
+    const firstAssistant = { name: `E2E-Test-${Date.now()}`, description: 'first' };
+    const secondAssistant = { name: `E2E-Test-${Date.now()}-B`, description: 'second' };
+
+    await test.step('should login', async () => {
+      await login(page);
+      await cleanup(page);
+    });
+    await test.step('should add two assistants', async () => {
+      await enterAdminArea(page);
+      await createConfiguration(page, firstAssistant);
+      await addAzureModelToConfiguration(page, firstAssistant, { deployment: 'gpt-4o-mini' });
+      await addSystemPromptToConfiguration(page, firstAssistant, { text: 'Always tell that your name is Bob' });
+      await createConfiguration(page, secondAssistant);
+      await addAzureModelToConfiguration(page, secondAssistant, { deployment: 'gpt-4o-mini' });
+      await addSystemPromptToConfiguration(page, secondAssistant, { text: 'Always tell that your name is Alice' });
+    });
+
+    await test.step('should return message for first assistant', async () => {
+      await enterUserArea(page);
+      await newChat(page);
+      await selectConfiguration(page, firstAssistant);
+
+      await sendMessage(page, firstAssistant, { message: 'Who are you' });
+
+      const firstResponse = await page.waitForSelector(`:has-text("Bob")`);
+      expect(firstResponse).toBeDefined();
+      const firstResponseAssistantText = await page.waitForSelector(`:has-text("${firstAssistant.name}")`);
+      expect(firstResponseAssistantText).toBeDefined();
+    });
+
+    await test.step('should return message for second assistant', async () => {
+      await selectConfiguration(page, secondAssistant);
+
+      await sendMessage(page, firstAssistant, { message: 'Who are you' });
+
+      const firstResponse = await page.waitForSelector(`:has-text("Bob")`);
+      expect(firstResponse).toBeDefined();
+      const firstResponseAssistantText = await page.waitForSelector(`:has-text("${firstAssistant.name}")`);
+      expect(firstResponseAssistantText).toBeDefined();
+      const secondResponse = await page.waitForSelector(`:has-text("Alice")`);
+      expect(secondResponse).toBeDefined();
+      const secondResponseAssistantText = await page.waitForSelector(`:has-text("${secondAssistant.name}")`);
+      expect(secondResponseAssistantText).toBeDefined();
+    });
+  });
+}

--- a/frontend/src/api/generated/models/MessageDto.ts
+++ b/frontend/src/api/generated/models/MessageDto.ts
@@ -40,6 +40,12 @@ export interface MessageDto {
      */
     id: number;
     /**
+     * The ID of the used configuration.
+     * @type {number}
+     * @memberof MessageDto
+     */
+    configurationId: number;
+    /**
      * The content.
      * @type {Array<MessageContentDto>}
      * @memberof MessageDto
@@ -112,6 +118,7 @@ export type MessageDtoRatingEnum = typeof MessageDtoRatingEnum[keyof typeof Mess
  */
 export function instanceOfMessageDto(value: object): value is MessageDto {
     if (!('id' in value) || value['id'] === undefined) return false;
+    if (!('configurationId' in value) || value['configurationId'] === undefined) return false;
     if (!('content' in value) || value['content'] === undefined) return false;
     if (!('type' in value) || value['type'] === undefined) return false;
     return true;
@@ -128,6 +135,7 @@ export function MessageDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     return {
         
         'id': json['id'],
+        'configurationId': json['configurationId'],
         'content': ((json['content'] as Array<any>).map(MessageContentDtoFromJSON)),
         'type': json['type'],
         'rating': json['rating'] == null ? undefined : json['rating'],
@@ -145,6 +153,7 @@ export function MessageDtoToJSON(value?: MessageDto | null): any {
     return {
         
         'id': value['id'],
+        'configurationId': value['configurationId'],
         'content': ((value['content'] as Array<any>).map(MessageContentDtoToJSON)),
         'type': value['type'],
         'rating': value['rating'],

--- a/frontend/src/pages/chat/conversation/ChatHistory.tsx
+++ b/frontend/src/pages/chat/conversation/ChatHistory.tsx
@@ -9,7 +9,7 @@ type ChatHistoryProps = {
   editMessage: (input: string, files?: FileDto[], editMessageId?: number) => void;
 };
 
-export function ChatHistory({ agentName, llmLogo, selectDocument, editMessage }: ChatHistoryProps) {
+export function ChatHistory({ agentName, selectDocument, editMessage }: ChatHistoryProps) {
   const messages = useStateOfMessages();
   const allMessagesButLastTwo = messages.slice(0, -2);
   const lastTwoMessages = messages.slice(-2);
@@ -26,7 +26,6 @@ export function ChatHistory({ agentName, llmLogo, selectDocument, editMessage }:
             isLast={i === messages.length - 1}
             isBeforeLast={i === messages.length - 2}
             message={message}
-            llmLogo={llmLogo}
             selectDocument={(documentUri) => selectDocument(chatId, message.id, documentUri)}
             editMessage={editMessage}
           />
@@ -40,7 +39,6 @@ export function ChatHistory({ agentName, llmLogo, selectDocument, editMessage }:
             isLast={i === 1}
             isBeforeLast={i === 0}
             message={message}
-            llmLogo={llmLogo}
             selectDocument={(documentUri) => selectDocument(chatId, message.id, documentUri)}
             editMessage={editMessage}
           />

--- a/frontend/src/pages/chat/conversation/ChatItem/ChatItemProps.tsx
+++ b/frontend/src/pages/chat/conversation/ChatItem/ChatItemProps.tsx
@@ -7,7 +7,6 @@ export interface ChatItemProps {
   isLast: boolean;
   isBeforeLast: boolean;
   rating?: MessageDtoRatingEnum;
-  llmLogo?: string;
   selectDocument: (documentUri: string) => void;
   editMessage: (input: string, files?: FileDto[], editMessageId?: number) => void;
 }

--- a/frontend/src/pages/chat/conversation/ConversationPage.tsx
+++ b/frontend/src/pages/chat/conversation/ConversationPage.tsx
@@ -40,8 +40,6 @@ export function ConversationPage(props: ConversationPageProps) {
 
   const isNewConversation = messages.length === 0 && !!history;
 
-  const llmLogo = assistant?.extensions?.find((x) => x.type === 'llm')?.logo;
-
   const agentName = useMemo(() => {
     return assistant?.agentName || theme.agentName || texts.chat.sourceAI;
   }, [assistant?.agentName, theme.agentName]);
@@ -84,7 +82,7 @@ export function ConversationPage(props: ConversationPageProps) {
               }
               ref={containerRef}
             >
-              <ChatHistory agentName={agentName} llmLogo={llmLogo} selectDocument={selectDocument} editMessage={submitMessage} />
+              <ChatHistory agentName={agentName} selectDocument={selectDocument} editMessage={submitMessage} />
             </div>
           )}
           <div className={`${!messages.length && 'grow'} flex shrink-0 flex-col items-center justify-center px-4`}>

--- a/frontend/src/pages/chat/conversation/ConversationPage.tsx
+++ b/frontend/src/pages/chat/conversation/ConversationPage.tsx
@@ -71,7 +71,7 @@ export function ConversationPage(props: ConversationPageProps) {
         </>
       )}
       <div className="bg-white p-3">
-        <Configuration canEditConfiguration={isNewConversation} />
+        <Configuration canEditConfiguration={true} />
       </div>
       {isChatLoading ? (
         <div className="fade-in w-full bg-white" style={{ height: 'calc(100vh - 4rem)' }} />

--- a/frontend/src/pages/chat/state/chat.ts
+++ b/frontend/src/pages/chat/state/chat.ts
@@ -71,12 +71,20 @@ export const useChatStream = (chatId: number) => {
       chatStore.setMessages(chatStore.messages.filter((message) => message.id > 0 && message.id < editMessageId));
     }
 
+    const configurationId = chatStore.chat.configurationId;
+
     chatStore.addMessage({
       type: 'human',
       content: [{ type: 'text', text: input }],
+      configurationId,
       id: editMessageId ?? getMessagePlaceholderId('human'),
     });
-    chatStore.addMessage({ type: 'ai', content: [{ type: 'text', text: '' }], id: getMessagePlaceholderId('ai') });
+    chatStore.addMessage({
+      type: 'ai',
+      configurationId,
+      content: [{ type: 'text', text: '' }],
+      id: getMessagePlaceholderId('ai'),
+    });
     chatStore.setIsAiWriting(true);
 
     chatStore.getStream(chatId, input, files, api, editMessageId).subscribe({


### PR DESCRIPTION
This is experimental not not yet suited for merging.

We still need to save at each ai message which assistant wrote it, to show the correct logo for old messages (see `get-history-middleware.ts`). 

We should make sure that this does not break anything unexpected.
