### PR TITLE
ci: remove appVersion check in Helm Chart version verification

### DIFF
--- a/.github/workflows/release-publish-chart-and-container-images.yaml
+++ b/.github/workflows/release-publish-chart-and-container-images.yaml
@@ -54,8 +54,7 @@ jobs:
 
       - name: Verify that chart version is correct
         run: |
-          if [ $(yq '.version' helm-chart/Chart.yaml) != "${{ steps.extract_ref.outputs.version }}" ] \
-          || [ $(yq '.appVersion' helm-chart/Chart.yaml) != "${{ steps.extract_ref.outputs.version }}" ]
+          if [ $(yq '.version' helm-chart/Chart.yaml) != "${{ steps.extract_ref.outputs.version }}" ]
           then
             echo "Version mismatch detected"
             exit 1


### PR DESCRIPTION
The field no longer exists as of d24e6f3df46e547f052f1044ea790a3e48cf3e10