### PR TITLE
fix(backend): increase failureThreshold in startupProbe to 5

### DIFF
--- a/helm-chart/templates/deployment-backend.yaml
+++ b/helm-chart/templates/deployment-backend.yaml
@@ -54,7 +54,7 @@ spec:
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 5
-            failureThreshold: 2
+            failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
The startupProbe was configured with a failureThreshold of 2. (Default is 3.) This was not enough in one case. Now the threshold is set to 5.