### PR TITLE
Fix/add ingress tls only if needed

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: c4-genai-suite
 description: A Helm chart for the c4 GenAI Suite.
-version: 8.5.3
+version: 9.0.0
 sources:
   - https://github.com/codecentric/c4-genai-suite/

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -26,7 +26,7 @@ helm install codecentric-c4-genai-suite oci://ghcr.io/codecentric/c4-genai-suite
 ingress:
   enabled: true
   host: c4.example.com
-  tlsSecretName: my-tls-cert
+  tls: true
 
 backend:
   auth:
@@ -68,14 +68,13 @@ reis:
 
 ### Ingress
 
-| Name                       | Description                                                                 | Value   |
-| -------------------------- | --------------------------------------------------------------------------- | ------- |
-| `ingress.enabled`          | Specifies whether an Ingress resource should be created.                    | `false` |
-| `ingress.ingressClassName` | The name of the ingressClass. One of: public-traefik, internal-traefik      | `""`    |
-| `ingress.clusterIssuer`    | The cluster issuer for Let's Encrypt. Should be `letsencrypt-<ENVIRONMENT>` | `""`    |
-| `ingress.host`             | The host for ingress                                                        | `""`    |
-| `ingress.tlsSecretName`    | The TLS secret name. Should be c4-tls-cert                                  | `""`    |
-| `ingress.annotations`      | Map of annotations to add for ingress                                       | `{}`    |
+| Name                       | Description                                                            | Value   |
+| -------------------------- | ---------------------------------------------------------------------- | ------- |
+| `ingress.enabled`          | Specifies whether an Ingress resource should be created.               | `false` |
+| `ingress.ingressClassName` | The name of the ingressClass. One of: public-traefik, internal-traefik | `""`    |
+| `ingress.host`             | The host for ingress                                                   | `""`    |
+| `ingress.annotations`      | Map of annotations to add for ingress                                  | `{}`    |
+| `ingress.tls`              | Specifies if a `tls` section should be created.                        | `false` |
 
 ### Backend
 
@@ -406,3 +405,11 @@ database (Azure OpenAI or PGVector).
 
 To achieve a zero-downtime migration, install the new chart in parallel with the old chart, verify that everything is
 working as expected, and then uninstall the old chart.
+
+## 8.5.3 to 9.0.0
+
+There are breaking changes regarding the Ingress resource:
+
+- TLS is no longer enabled by default. To enable it, you have to set `ingress.tls` to `true`.
+- The value `ingress.tlsSecretName` is no longer required and should be removed.
+- The cluster issuer can no longer be set via the value `ingress.clusterIssuer`. You have to add the annotation `cert-manager.io/cluster-issuer: <your-issuer>` for yourself by adding it to the value `ingress.annotations`.

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -6,11 +6,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "c4genaisuite.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer }}
-    {{- if .Values.ingress.annotations }}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{ include "c4genaisuite.commonLabels" . | nindent 4 }}
     app.kubernetes.io/component: ingress
@@ -38,8 +37,10 @@ spec:
                 port:
                   name: http
           {{- end }}
+  {{ if .Values.ingress.tls }}
   tls:
-    - secretName: {{ .Values.ingress.tlsSecretName }}
+    - secretName: {{ printf "%s-tls" .Values.ingress.host }}
       hosts:
         - {{ .Values.ingress.host }}
+  {{- end }}
 {{- end }}

--- a/helm-chart/tests/ingress_test.yaml
+++ b/helm-chart/tests/ingress_test.yaml
@@ -33,18 +33,31 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-my-custom-name
 
-  - it: leaves the TLS secret name empty by default
+  - it: does not create the TLS section by default
     asserts:
-      - isNullOrEmpty:
-          path: spec.tls[0].secretName
+      - notExists:
+          path: spec.tls
 
-  - it: sets the TLS secret name to the correct value if provided
+  - it: sets the TLS secret name to the chart name plus a suffix
     set:
-      ingress.tlsSecretName: "my-tls-cert"
+      ingress.tls: true
+      ingress.host: "c4.example.com"
     asserts:
       - equal:
           path: spec.tls[0].secretName
-          value: "my-tls-cert"
+          value: "c4.example.com-tls"
+
+  - it: sets the first TLS host to the ingress host
+    set:
+      ingress.tls: true
+      ingress.host: "c4.example.com"
+    asserts:
+      - lengthEqual:
+          path: spec.tls[0].hosts
+          count: 1
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: "c4.example.com"
 
   - it: sets the host name correctly
     set:
@@ -56,3 +69,16 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: "c4.example.com"
+
+  - it: sets custom ingress annotations
+    set:
+      ingress.annotations:
+        piff: paff
+        smack: whack
+    asserts:
+      - equal:
+          path: metadata.annotations.piff
+          value: paff
+      - equal:
+          path: metadata.annotations.smack
+          value: whack

--- a/helm-chart/values.schema.json
+++ b/helm-chart/values.schema.json
@@ -45,25 +45,20 @@
                     "description": "The name of the ingressClass. One of: public-traefik, internal-traefik",
                     "default": "\"\""
                 },
-                "clusterIssuer": {
-                    "type": "string",
-                    "description": "The cluster issuer for Let's Encrypt. Should be `letsencrypt-<ENVIRONMENT>`",
-                    "default": "\"\""
-                },
                 "host": {
                     "type": "string",
                     "description": "The host for ingress",
-                    "default": "\"\""
-                },
-                "tlsSecretName": {
-                    "type": "string",
-                    "description": "The TLS secret name. Should be c4-tls-cert",
                     "default": "\"\""
                 },
                 "annotations": {
                     "type": "object",
                     "description": "Map of annotations to add for ingress",
                     "default": {}
+                },
+                "tls": {
+                    "type": "boolean",
+                    "description": "Specifies if a `tls` section should be created.",
+                    "default": false
                 }
             }
         },

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -18,14 +18,12 @@ ingress:
   enabled: false
   ## @param ingress.ingressClassName [string] The name of the ingressClass. One of: public-traefik, internal-traefik
   ingressClassName: ""
-  ## @param ingress.clusterIssuer [string] The cluster issuer for Let's Encrypt. Should be `letsencrypt-<ENVIRONMENT>`
-  clusterIssuer: ""
   ## @param ingress.host [string] The host for ingress
   host: ""
-  ## @param ingress.tlsSecretName [string] The TLS secret name. Should be c4-tls-cert
-  tlsSecretName: ""
   ## @param ingress.annotations Map of annotations to add for ingress
   annotations: {}
+  ## @param ingress.tls Specifies if a `tls` section should be created.
+  tls: false
 
 ## @section Backend
 backend:


### PR DESCRIPTION
This PR solves two issues:

1. In some clusters the tls section in the Ingress resource is not needed. In this case the section must not be added.
2. Some clusters issue certificates in a different way than prescribed by the current Ingress template. The annotation `cert-manager.io/cluster-issuer` should only be added if the value `ingress.clusterIssuer` is set.