### PR TITLE
fix: break long words instead of horizontal scrolling

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -102,7 +102,7 @@ function Code(props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, 
   };
 
   return match && typeof children === 'string' ? (
-    <div className="group relative">
+    <div className="group relative overflow-x-scroll">
       <Prism {...other} language={match[1]} style={vscDarkPlus} customStyle={{ backgroundColor: 'transparent', padding: 0 }}>
         {children.replace(/\n$/, '')}
       </Prism>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,3 +168,7 @@ input[type='number'] {
     @apply bg-white;
   }
 }
+
+* {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
For code blocks long words are preserved, but the codeblock can be scrolled horizontally.