### PR TITLE
feat: titles for system prompts

### DIFF
--- a/backend/src/extensions/other/custom.ts
+++ b/backend/src/extensions/other/custom.ts
@@ -15,6 +15,12 @@ export class CustomPromptExtension implements Extension<CustomPromptExtensionCon
       description: this.i18n.t('texts.extensions.customPrompt.description'),
       type: 'other',
       arguments: {
+        title: {
+          type: 'string',
+          title: this.i18n.t('texts.extensions.common.title'),
+          required: true,
+          showInList: true,
+        },
         text: {
           type: 'string',
           title: this.i18n.t('texts.extensions.common.text'),

--- a/backend/src/localization/i18n/de/texts.json
+++ b/backend/src/localization/i18n/de/texts.json
@@ -37,6 +37,7 @@
       "size": "Größe",
       "bucket": "Bucket",
       "take": "Take",
+      "title": "Titel",
       "fileIds": "Datei-IDs",
       "temperatureHint": "Höhere Werte wie 0.8 machen die Ausgabe zufälliger, während niedrigere Werte wie 0.2 die Ausgabe fokussierter und deterministischer machen.",
       "seedHint": "Dieses Feature befindet sich in der Beta-Phase. Wenn angegeben, wird OpenAI versuchen, deterministisch zu arbeiten, sodass wiederholte Anfragen mit demselben Seed und denselben Parametern das gleiche Ergebnis liefern sollten.",

--- a/backend/src/localization/i18n/en/texts.json
+++ b/backend/src/localization/i18n/en/texts.json
@@ -37,6 +37,7 @@
       "size": "Size",
       "bucket": "Bucket",
       "take": "Take",
+      "title": "Title",
       "fileIds": "File IDs",
       "temperatureHint": "Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
       "seedHint": "This feature is in Beta. If specified, OpenAI will make a best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result.",

--- a/e2e/tests/utils/helper.ts
+++ b/e2e/tests/utils/helper.ts
@@ -456,7 +456,7 @@ export async function configureAssistantByUser(page: Page, config: { values: { l
 export async function addSystemPromptToConfiguration(
   page: Page,
   configuration: { name: string },
-  prompt: { text: string; configurable?: boolean },
+  prompt: { title?: string; text: string; configurable?: boolean },
 ) {
   await page.getByRole('link', { name: 'Assistants' }).click();
   await page.getByRole('link').filter({ hasText: configuration.name }).click();
@@ -466,6 +466,7 @@ export async function addSystemPromptToConfiguration(
   await page.getByLabel('Create Extension').getByRole('tab', { name: 'Other' }).click();
 
   await page.getByRole('heading', { name: 'Prompt', exact: true }).click();
+  await page.getByLabel('Title').fill(prompt.title ?? 'systemprompt');
   await page.getByLabel('Text').fill(prompt.text);
 
   if (prompt.configurable) {


### PR DESCRIPTION
The system prompt extension now requires a title
which will be shown in the overview. 

Closes #290