### PR TITLE
fix: tell the LLM which output formats are supported by c4

### DIFF
--- a/backend/src/domain/chat/middlewares/default-prompt-middleware.ts
+++ b/backend/src/domain/chat/middlewares/default-prompt-middleware.ts
@@ -8,7 +8,9 @@ export class DefaultPromptMiddleware implements ChatMiddleware {
 
   async invoke(context: ChatContext, getContext: GetContext, next: ChatNextDelegate): Promise<any> {
     if (context.systemMessages.length === 0) {
-      context.systemMessages.push("You are a helpful assistant. Today's date is {{date}}.");
+      context.systemMessages.push(
+        "You are a helpful assistant. Today's date is {{date}}. You can use Markdown notation for text and tables. You can use LaTeX notation for equations enclosed in `$` or `$$`. When returning code, json, csv or other codelike content, format it inside markdown fenced code blocks. Indicate the language on the fenced code block if at all possible.",
+      );
     }
     await next(context);
   }


### PR DESCRIPTION
This is done via the default system prompt. Note that the default system prompt will be disabled when using a custom system prompt extension. In that case a similar prompt might be added via a custom prompt extension.

Closes #630 