### PR TITLE
fix(backend): auto-append /api to Ollama endpoint for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Now you can return to the [chat page](http://localhost:3333/chat) (click on `c4 
 
 > [!TIP]
 > Our `docker-compose` includes a local Ollama, which runs on the CPU. You can use this for quick testing. But it will be slow and you probably want to use another model. If you want to use it, just create the following model extension in your Assistant.
-> * Extension: `Dev: Ollama`
+> * Extension: `Ollama`
 > * Endpoint: `http://ollama:11434`
 > * Model: `llama3.2`
 

--- a/backend/src/extensions/models/ollama.ts
+++ b/backend/src/extensions/models/ollama.ts
@@ -61,9 +61,14 @@ export class OllamaModelExtension implements Extension<OllamaModelExtensionConfi
   private createModel(configuration: OllamaModelExtensionConfiguration, streaming = false) {
     const { endpoint, modelName } = configuration;
 
+    // Ensure endpoint ends with /api for compatibility with ollama-ai-provider-v2
+    // The provider appends /chat to baseURL, so we need baseURL to be http://host:port/api
+    // Ollama API endpoints are: /api/chat, /api/generate, etc.
+    const normalizedEndpoint = this.normalizeEndpoint(endpoint);
+
     const open = createOllama({
       name: 'ollama',
-      baseURL: endpoint,
+      baseURL: normalizedEndpoint,
       fetch: fetchWithDebugLogging(OllamaModelExtension.name),
     });
 
@@ -75,6 +80,19 @@ export class OllamaModelExtension implements Extension<OllamaModelExtensionConfi
       modelName: modelName,
       providerName: 'ollama',
     };
+  }
+
+  private normalizeEndpoint(endpoint: string): string {
+    // Remove trailing slash
+    const trimmedEndpoint = endpoint.replace(/\/$/, '');
+
+    // If endpoint already ends with /api, use it as-is
+    if (trimmedEndpoint.endsWith('/api')) {
+      return trimmedEndpoint;
+    }
+
+    // Otherwise, append /api
+    return `${trimmedEndpoint}/api`;
   }
 }
 


### PR DESCRIPTION
When I tried to run docker compose and set up ollama I ran into two minor issues and I quickly fixed them:

1) The ollama-ai-provider-v2 library expects the baseURL to include the /api prefix, as it appends /chat, /generate, etc. to construct full endpoint URLs.

Without this fix, users had to manually add /api to their endpoint configuration, otherwise they would get a 404 Not Found error when testing the extension.

This change automatically normalizes the endpoint to include /api if not present, while handling trailing slashes and maintaining backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

2) Also fixed a naming issue regarding the Ollama extension in readme.md (it was not in line with the UI options in the latest version)

**Regarding testing**
_Please note:_ I tested in dev mode through docker to avoid the full local install (for time reasons), now "http://ollama:11434" and "http://ollama:11434/api" work fine as endpoint names. I did not run the full test suite, because the fixes are rather small and I understand it will be run through GitHub actions anyways.