### PR TITLE
fix(REIS): do not process all file types with a detour over pdf when previews are activated

### DIFF
--- a/services/reis/rei_s/services/formats/abstract_format_provider.py
+++ b/services/reis/rei_s/services/formats/abstract_format_provider.py
@@ -29,5 +29,16 @@ class AbstractFormatProvider(ABC):
         return True
 
     @property
-    def multiprocessable(self) -> bool:
+    def previewable(self) -> bool:
+        """Whether this provider offers a sensible pdf preview."""
+        return True
+
+    @property
+    def may_start_separate_process_for_chunking(self) -> bool:
+        """Whether this provider benefits from processing in a separate process."""
+        return True
+
+    @property
+    def may_start_separate_process_for_converting(self) -> bool:
+        """Whether this provider benefits from converting to a pdf preview in a separate process."""
         return True

--- a/services/reis/rei_s/services/formats/libre_office_provider.py
+++ b/services/reis/rei_s/services/formats/libre_office_provider.py
@@ -13,4 +13,4 @@ class LibreOfficeProvider(OfficeProvider):
     ]
 
     def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 200, **_kwargs: Any) -> None:
-        super().__init__()
+        super().__init__(chunk_size, chunk_overlap, **_kwargs)

--- a/services/reis/rei_s/services/formats/ms_excel_provider.py
+++ b/services/reis/rei_s/services/formats/ms_excel_provider.py
@@ -9,4 +9,4 @@ class MsExcelProvider(OfficeProvider):
     file_name_extensions = [".xlsx"]
 
     def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 200, **_kwargs: Any) -> None:
-        super().__init__()
+        super().__init__(chunk_size, chunk_overlap, **_kwargs)

--- a/services/reis/rei_s/services/formats/ms_ppt_provider.py
+++ b/services/reis/rei_s/services/formats/ms_ppt_provider.py
@@ -8,4 +8,4 @@ class MsPptProvider(OfficeProvider):
     file_name_extensions = [".pptx"]
 
     def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 200, **_kwargs: Any) -> None:
-        super().__init__()
+        super().__init__(chunk_size, chunk_overlap, **_kwargs)

--- a/services/reis/rei_s/services/formats/ms_word_provider.py
+++ b/services/reis/rei_s/services/formats/ms_word_provider.py
@@ -9,4 +9,4 @@ class MsWordProvider(OfficeProvider):
     file_name_extensions = [".docx"]
 
     def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 200, **_kwargs: Any) -> None:
-        super().__init__()
+        super().__init__(chunk_size, chunk_overlap, **_kwargs)

--- a/services/reis/rei_s/services/formats/office_provider.py
+++ b/services/reis/rei_s/services/formats/office_provider.py
@@ -33,7 +33,12 @@ class OfficeProvider(AbstractFormatProvider):
         return PdfProvider().process_file(pdf, chunk_size, chunk_overlap)
 
     @property
-    def multiprocessable(self) -> bool:
+    def may_start_separate_process_for_chunking(self) -> bool:
+        # office files are converted to pdf and then processed with the pdf provider
+        return PdfProvider().may_start_separate_process_for_chunking
+
+    @property
+    def may_start_separate_process_for_converting(self) -> bool:
         # office files are converted in libreoffice, which is already a subprocess
         # no need to wrap it in our own subprocess
         return False

--- a/services/reis/rei_s/services/formats/pdf_provider.py
+++ b/services/reis/rei_s/services/formats/pdf_provider.py
@@ -102,6 +102,11 @@ class PdfProvider(AbstractFormatProvider):
 
         return chunks
 
+    @property
+    def may_start_separate_process_for_converting(self) -> bool:
+        # pdf files are converted to pdf by a simple copy, which does not need a subprocess
+        return False
+
     def convert_file_to_pdf(self, file: SourceFile) -> SourceFile:
         path = get_new_file_path(extension="pdf")
         shutil.copy(file.path, path)

--- a/services/reis/rei_s/services/formats/utils.py
+++ b/services/reis/rei_s/services/formats/utils.py
@@ -81,6 +81,10 @@ def generate_pdf_from_md(markdown_text: str, doc_id: str, file_name: str) -> Sou
 
 
 def convert_office_to_pdf(file: SourceFile) -> SourceFile:
+    # If we already have a preview PDF, use it
+    if file.preview_pdf_cache is not None and file.preview_pdf_cache.exists:
+        return file.preview_pdf_cache
+
     output_dir = Path(tempfile.gettempdir()) / uuid4().hex
     output_dir.mkdir(parents=True, exist_ok=True)
     libreoffice_home = Path(tempfile.gettempdir()) / uuid4().hex
@@ -121,4 +125,7 @@ def convert_office_to_pdf(file: SourceFile) -> SourceFile:
     pdf_name = os.path.splitext(base)[0] + ".pdf"
     pdf_path = os.path.join(output_dir, pdf_name)
 
-    return SourceFile(id=file.id, path=pdf_path, mime_type="application/pdf", file_name=file.file_name, delete_dir=True)
+    pdf = SourceFile(id=file.id, path=pdf_path, mime_type="application/pdf", file_name=file.file_name, delete_dir=True)
+    file.preview_pdf_cache = pdf
+
+    return pdf

--- a/services/reis/rei_s/services/formats/voice_transcription_provider.py
+++ b/services/reis/rei_s/services/formats/voice_transcription_provider.py
@@ -103,7 +103,7 @@ class VoiceTranscriptionProvider(AbstractFormatProvider):
         return self.parser is not None
 
     @property
-    def multiprocessable(self) -> bool:
+    def may_start_separate_process_for_chunking(self) -> bool:
         return False
 
     @staticmethod
@@ -223,6 +223,11 @@ class VoiceTranscriptionProvider(AbstractFormatProvider):
 
         chunks = self.splitter(chunk_size, chunk_overlap).split_documents(results)
         return chunks
+
+    @property
+    def previewable(self) -> bool:
+        # a plaintext audio transcription is not a sensible pdf preview
+        return False
 
     def convert_file_to_pdf(self, file: SourceFile) -> SourceFile:
         docs = self.parse_file(file)


### PR DESCRIPTION
This comes with a trade off for the pdf viewer in the frontend. Until now, every file type could jump to the correct page in the preview pdf. But the price to pay was that every type was converted to pdf and then parsed and chunked, which leads to worse results and in most cases longer processing times.

Now we generate a pdf for each format, but parse the original -- with the exception of the office file formats. This way we can show the preview pdf, but can not jump to the page.

Also this PR:

* simplifies the code somewhat
* clarifies the names of some properties
* does microoptimization, which avoids conversion of the same file multiple times
* fixes a bug that chunk_size was ignored for office formats