### PR TITLE
feat: Add option to extend vs replace default systemprompt (fixes #652)

### DIFF
--- a/backend/src/domain/chat/interfaces.ts
+++ b/backend/src/domain/chat/interfaces.ts
@@ -208,6 +208,9 @@ export interface ChatContext {
   // The system messages.
   systemMessages: string[];
 
+  // Whether to replace the default system prompt (set by custom prompt extension).
+  replaceDefaultPrompt?: boolean;
+
   // The deployment.
   readonly configuration: ConfigurationModel;
 

--- a/backend/src/domain/chat/middlewares/default-prompt-middleware.ts
+++ b/backend/src/domain/chat/middlewares/default-prompt-middleware.ts
@@ -7,8 +7,9 @@ export class DefaultPromptMiddleware implements ChatMiddleware {
   order = ExecuteMiddleware.ORDER - 10;
 
   async invoke(context: ChatContext, getContext: GetContext, next: ChatNextDelegate): Promise<any> {
-    if (context.systemMessages.length === 0) {
-      context.systemMessages.push(
+    // Only add default prompt if custom prompt extension didn't request to replace it
+    if (!context.replaceDefaultPrompt) {
+      context.systemMessages.unshift(
         "You are a helpful assistant. Today's date is {{date}}. You can use Markdown notation for text and tables. You can use LaTeX notation for equations enclosed in `$` or `$$`. When returning code, json, csv or other codelike content, format it inside markdown fenced code blocks. Indicate the language on the fenced code block if at all possible.",
       );
     }

--- a/backend/src/extensions/other/custom.ts
+++ b/backend/src/extensions/other/custom.ts
@@ -28,6 +28,13 @@ export class CustomPromptExtension implements Extension<CustomPromptExtensionCon
           required: false,
           description: this.i18n.t('texts.extensions.customPrompt.templateDescription'),
         },
+        replaceDefault: {
+          type: 'boolean',
+          title: this.i18n.t('texts.extensions.customPrompt.replaceDefaultTitle'),
+          description: this.i18n.t('texts.extensions.customPrompt.replaceDefaultDescription'),
+          default: false,
+          required: false,
+        },
       },
     };
   }
@@ -35,7 +42,13 @@ export class CustomPromptExtension implements Extension<CustomPromptExtensionCon
   getMiddlewares(_: User, extension: ExtensionEntity<CustomPromptExtensionConfiguration>): Promise<ChatMiddleware[]> {
     const middleware = {
       invoke: async (context: ChatContext, getContext: GetContext, next: ChatNextDelegate): Promise<any> => {
-        const { text } = extension.values;
+        const { text, replaceDefault } = extension.values;
+
+        // If replaceDefault is true, set flag to skip default prompt
+        if (replaceDefault) {
+          context.replaceDefaultPrompt = true;
+        }
+
         if (text) {
           context.systemMessages.push(text);
         }
@@ -48,4 +61,4 @@ export class CustomPromptExtension implements Extension<CustomPromptExtensionCon
   }
 }
 
-type CustomPromptExtensionConfiguration = ExtensionConfiguration & { text: string };
+type CustomPromptExtensionConfiguration = ExtensionConfiguration & { text: string; replaceDefault?: boolean };

--- a/backend/src/localization/i18n/de/texts.json
+++ b/backend/src/localization/i18n/de/texts.json
@@ -90,7 +90,9 @@
     "customPrompt": {
       "title": "Prompt",
       "description": "Verwendet einen freien Text als Systemnachricht.",
-      "templateDescription": "Der Text kann bestimmte Platzhalter enthalten, die zur Laufzeit ersetzt werden. Verfügbare Platzhalter:\n\n* `{{{{date}}}}`: Tagesdatum\n* `{{{{timestamp}}}}`: Aktuelles Datum und Uhrzeit\n* `{{{{llm_name}}}}`: Name des Modells\n* `{{{{llm_provider}}}}`: Betreiber des Modells\n* `{{{{user}}}}`: Username oder Email\n* `{{{{assistant}}}}`: Name des Assistenten\n* `{{{{assistant_description}}}}`: Beschreibung des Assistenten"
+      "templateDescription": "Der Text kann bestimmte Platzhalter enthalten, die zur Laufzeit ersetzt werden. Verfügbare Platzhalter:\n\n* `{{{{date}}}}`: Tagesdatum\n* `{{{{timestamp}}}}`: Aktuelles Datum und Uhrzeit\n* `{{{{llm_name}}}}`: Name des Modells\n* `{{{{llm_provider}}}}`: Betreiber des Modells\n* `{{{{user}}}}`: Username oder Email\n* `{{{{assistant}}}}`: Name des Assistenten\n* `{{{{assistant_description}}}}`: Beschreibung des Assistenten",
+      "replaceDefaultTitle": "Standard-Systemprompt ersetzen",
+      "replaceDefaultDescription": "Wenn aktiviert, ersetzt der benutzerdefinierte Prompt den Standard-Systemprompt vollständig. Wenn deaktiviert (Standard), erweitert der benutzerdefinierte Prompt den Standard-Systemprompt."
     },
     "hubPrompt": {
       "title": "Hub Prompt",

--- a/backend/src/localization/i18n/en/texts.json
+++ b/backend/src/localization/i18n/en/texts.json
@@ -90,7 +90,9 @@
     "customPrompt": {
       "title": "Prompt",
       "description": "Uses a free prompt text as system message.",
-      "templateDescription": "The text may contain certain placeholders that are replaced at runtime. Available placeholders:\n\n* `{{{{date}}}}`: today's date\n* `{{{{timestamp}}}}`: current date and time\n* `{{{{llm_name}}}}`: model name\n* `{{{{llm_provider}}}}`: model provider\n* `{{{{user}}}}`: username or email\n* `{{{{assistant}}}}`: assistant name\n* `{{{{assistant_description}}}}`: assistant description"
+      "templateDescription": "The text may contain certain placeholders that are replaced at runtime. Available placeholders:\n\n* `{{{{date}}}}`: today's date\n* `{{{{timestamp}}}}`: current date and time\n* `{{{{llm_name}}}}`: model name\n* `{{{{llm_provider}}}}`: model provider\n* `{{{{user}}}}`: username or email\n* `{{{{assistant}}}}`: assistant name\n* `{{{{assistant_description}}}}`: assistant description",
+      "replaceDefaultTitle": "Replace default systemprompt",
+      "replaceDefaultDescription": "When enabled, the custom prompt replaces the default systemprompt entirely. When disabled (default), the custom prompt extends the default systemprompt."
     },
     "hubPrompt": {
       "title": "Hub Prompt",


### PR DESCRIPTION
The custom systemprompt extension now supports both extending and replacing the default systemprompt, giving users more control over prompt behavior.

Changes:
- Add 'replaceDefault' boolean field to custom prompt extension
- Add 'replaceDefaultPrompt' property to ChatContext interface
- Update DefaultPromptMiddleware to respect replaceDefaultPrompt flag
- Change DefaultPromptMiddleware to use unshift (prepend) instead of checking for empty array
- Update CustomPromptExtension middleware to set flag when replaceDefault is true
- Add English and German localization for the new option

Behavior:
- Default (replaceDefault=false): Custom prompt extends the default → systemMessages = [default, custom]
- Optional (replaceDefault=true): Custom prompt replaces the default → systemMessages = [custom]
- No custom prompt: Default is used → systemMessages = [default]

This addresses the issue where users couldn't combine their custom instructions with helpful default instructions about Markdown/LaTeX support.