### PR TITLE
chore(deps): replace expr-eval with expr-eval-fork

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -42,7 +42,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
         "duck-duck-scrape": "^2.2.7",
-        "expr-eval": "^2.0.2",
+        "expr-eval-fork": "^3.0.1",
         "express-session": "^1.18.2",
         "json-diff-ts": "^4.6.3",
         "langfuse-vercel": "^3.38.5",
@@ -9900,11 +9900,14 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/expr-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
-      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
-      "license": "MIT"
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.1.tgz",
+      "integrity": "sha512-JRex9aykIt6AqhcQK+u1bFcBy2f+muwJoGCtAZmOC0yrktaCegtH42sLnZdNsD2/Ko9j+3pLWi4nIkNQez02bg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/express": {
       "version": "5.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -68,7 +68,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "duck-duck-scrape": "^2.2.7",
-    "expr-eval": "^2.0.2",
+    "expr-eval-fork": "^3.0.1",
     "express-session": "^1.18.2",
     "json-diff-ts": "^4.6.3",
     "langfuse-vercel": "^3.38.5",

--- a/backend/src/extensions/tools/calculator.ts
+++ b/backend/src/extensions/tools/calculator.ts
@@ -1,4 +1,4 @@
-import { Parser } from 'expr-eval';
+import { Parser } from 'expr-eval-fork';
 import z from 'zod';
 import { ChatContext, ChatMiddleware, ChatNextDelegate, GetContext, NamedStructuredTool } from 'src/domain/chat';
 import { Extension, ExtensionSpec } from 'src/domain/extensions';


### PR DESCRIPTION
since the former seems to be unmaintained.

This fixes CVE-2025-12735 and CVE-2025-13204