### PR TITLE
chore: use unique job names for GitHub Actions

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -14,7 +14,7 @@ defaults:
     working-directory: backend
 
 jobs:
-  build:
+  backend-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -26,7 +26,7 @@ jobs:
       - run: npm install
       - run: npm run build
 
-  check-generated-files:
+  backend-check-generated-files:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
       - run: npm run generate-${{ matrix.service }}
       - run: git diff --quiet # exits with exitcode != 0 if changes are detected
 
-  check-generated-specs:
+  backend-check-generated-specs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -57,7 +57,7 @@ jobs:
       - run: git diff .
       - run: git diff --quiet .
 
-  lint:
+  backend-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -69,7 +69,7 @@ jobs:
       - run: npm install
       - run: npm run lint
 
-  test:
+  backend-test:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -176,7 +176,7 @@ jobs:
             END IF;
             END;
             $function$ LANGUAGE plpgsql;
-            
+
             CREATE EVENT TRIGGER prevent_schema_creation_trigger
             ON ddl_command_start
             WHEN TAG IN ('CREATE SCHEMA')

--- a/.github/workflows/confluence-importer.yaml
+++ b/.github/workflows/confluence-importer.yaml
@@ -14,7 +14,7 @@ defaults:
     working-directory: services/confluence-importer
 
 jobs:
-  format-check:
+  confluence-importer-format-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -28,7 +28,7 @@ jobs:
       - name: Check formatting with ruff
         run: uv run ruff format --check .
 
-  lint:
+  confluence-importer-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
       - name: Lint with mypy
         run: uv run mypy .
 
-  test:
+  confluence-importer-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,12 +20,12 @@ defaults:
     working-directory: e2e
 
 jobs:
-  build:
+  e2e-build:
     uses: ./.github/workflows/build-container-images.yaml
 
   e2e:
     needs:
-      - build
+      - e2e-build
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +41,7 @@ jobs:
       testdir: ${{ matrix.testdir }}
     secrets: inherit
 
-  lint:
+  e2e-lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -14,7 +14,7 @@ defaults:
     working-directory: frontend
 
 jobs:
-  build:
+  frontend-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -26,7 +26,7 @@ jobs:
       - run: npm install
       - run: npm run build
 
-  check-generated-files:
+  frontend-check-generated-files:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
       # exits with exitcode != 0 if changes are detected
       - run: git diff --quiet .
 
-  lint:
+  frontend-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,7 +55,7 @@ jobs:
       - run: npm run lint
       - run: npm run find-unused-resources
 
-  test:
+  frontend-test:
     runs-on: ubuntu-latest
     env:
       VITE_SERVER_URL: http://localhost:5173/api-proxy

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 jobs:
-  unittest:
+  helmchart-unittest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/reis-stresstest.yaml
+++ b/.github/workflows/reis-stresstest.yaml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
 
-  build-reis-if-needed:
+  reis-build-if-needed:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v7
@@ -48,9 +48,9 @@ jobs:
           path: /tmp/reis.tar
           retention-days: 2
 
-  test-stress:
+  reis-test-stress:
     runs-on: ubuntu-latest
-    needs: build-reis-if-needed
+    needs: reis-build-if-needed
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/reis.yaml
+++ b/.github/workflows/reis.yaml
@@ -14,7 +14,7 @@ defaults:
     working-directory: services/reis
 
 jobs:
-  check-generated-specs:
+  reis-check-generated-specs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -33,7 +33,7 @@ jobs:
           poetry run ruff format reis-dev-spec.json
           diff reis-dev-spec.json reis-spec.json
 
-  lint:
+  reis-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +49,7 @@ jobs:
           poetry -vvv run ruff check .
           poetry -vvv run mypy .
 
-  test:
+  reis-test:
     runs-on: ubuntu-latest
     services:
       pgvector:

--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -8,7 +8,7 @@ on:
       - created
 
 jobs:
-  notify_slack:
+  notify-slack:
     runs-on: ubuntu-latest
     name: Notify Slack on Release
     steps:


### PR DESCRIPTION
if job names are identical our quality gate can be confused and the status of a failing "lint" job in the front can be overwritten by a succeeding lint job in the backend, resulting in a broken main.