### PR TITLE
chore: fix frontend linter pipeline error

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,4 +1,4 @@
 {
   "ignore": ["**/generated/**", "**/dist/**", "**/*.d.ts", "lint-staged.config.mjs", "**/mock/**", "public/**"],
-  "ignoreDependencies": ["eslint-*", "msw-auto-mock", "tailwindcss", "@tailwindcss/typography", "daisyui"]
+  "ignoreDependencies": ["eslint-*", "msw-auto-mock"]
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "katex": "^0.16.27",
         "mantine-form-zod-resolver": "^1.3.0",
         "msw": "^2.12.7",
+        "pdfjs-dist": "^5.3.31",
         "query-string": "^9.1.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "katex": "^0.16.27",
     "mantine-form-zod-resolver": "^1.3.0",
     "msw": "^2.12.7",
+    "pdfjs-dist": "^5.3.31",
     "query-string": "^9.1.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",


### PR DESCRIPTION
add pdfjs-dist to dependencies, since we use it directly