### PR TITLE
fix(REIS): handle json root lists correctly

### DIFF
--- a/services/reis/rei_s/services/formats/json_provider.py
+++ b/services/reis/rei_s/services/formats/json_provider.py
@@ -27,6 +27,8 @@ class JsonProvider(AbstractFormatProvider):
         text = file.buffer.decode()
 
         json_dict = json.loads(text)
+        if not isinstance(json_dict, dict):
+            json_dict = {"data": json_dict}
 
         chunks = self.splitter(chunk_size).create_documents([json_dict])
         return chunks


### PR DESCRIPTION
our json processing can only handle json which is a dict on top level. When we encounter a top level list, we will wrap it in a dict.