### PR TITLE
fix: repair api-keys auth

### DIFF
--- a/backend/src/controllers/auth/dtos/index.ts
+++ b/backend/src/controllers/auth/dtos/index.ts
@@ -127,7 +127,7 @@ export class ProfileDto {
     const result = new ProfileDto();
     result.id = source.id;
     result.email = source.email;
-    result.isAdmin = Array.isArray(source.userGroupIds) && source.userGroupIds.includes(BUILTIN_USER_GROUP_ADMIN);
+    result.isAdmin = Array.isArray(source.userGroups) && source.userGroups.map((x) => x.id).includes(BUILTIN_USER_GROUP_ADMIN);
     result.name = source.name ?? source.email;
     result.picture = source.picture;
 

--- a/backend/src/domain/auth/role.guard.ts
+++ b/backend/src/domain/auth/role.guard.ts
@@ -23,7 +23,9 @@ export class RoleGuard implements CanActivate {
     const request: Request = context.switchToHttp().getRequest();
 
     if (requiredRole === 'admin') {
-      return Array.isArray(request.user?.userGroupIds) && request.user.userGroupIds.includes(BUILTIN_USER_GROUP_ADMIN);
+      return (
+        Array.isArray(request.user?.userGroups) && request.user.userGroups.map((x) => x.id).includes(BUILTIN_USER_GROUP_ADMIN)
+      );
     }
 
     return !!request.user;

--- a/backend/src/domain/users/interfaces.ts
+++ b/backend/src/domain/users/interfaces.ts
@@ -12,6 +12,8 @@ export interface User {
   picture?: string;
 
   // The user group IDs.
+  // FIXME migrate this to use UserGroups instead of UserGroupIds
+  userGroups?: UserGroup[];
   userGroupIds: string[];
 
   // Indicates if the user has a password configured.


### PR DESCRIPTION
We broke authorization for api-keys with the "multiple groups per user" update (see link below). We need to use `userGroups` instead of `userGroupIds` since the latter does not exist on user objects anymore.

https://github.com/codecentric/c4-genai-suite/pull/467/files#diff-3e239b9c3af2bc414eaf63ffcf138921b0ad4391e7f4183fd0e32f43a9fb18c4L41