### PR TITLE
fix(frontend): default theme name is briefly shown as page title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>c4 GenAI Suite</title>
+    <title></title>
   </head>
   <body>
     <div id="head"></div>


### PR DESCRIPTION
Set page title to empty string and only use the default theme name if the theme could not be loaded or if it does not define a name.

Refs: 1315