### PR TITLE
chore: disable WebKit in E2E test matrix

### DIFF
--- a/.github/workflows/e2e-complete.yaml
+++ b/.github/workflows/e2e-complete.yaml
@@ -25,7 +25,7 @@ jobs:
         browser:
           - chromium
           - firefox
-          - webkit
+          # - webkit
         testdir:
           - expensive-tests
           - tests


### PR DESCRIPTION
Webkit Tests are slow and flakey.