### PR TITLE
fix(frontend): sort configurations alphabetically after duplicate

### DIFF
--- a/frontend/src/pages/admin/extensions/state.ts
+++ b/frontend/src/pages/admin/extensions/state.ts
@@ -102,6 +102,8 @@ const useConfigurationStore_ = create<ConfigurationState & ConfigurationActions>
         configurations.push(configuration);
       }
 
+      configurations.sort((a, b) => a.name.localeCompare(b.name));
+
       return { configurations: configurations };
     });
   },

--- a/frontend/src/pages/admin/extensions/state.ui-unit.spec.ts
+++ b/frontend/src/pages/admin/extensions/state.ui-unit.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ConfigurationDto } from 'src/api';
+import { useConfigurationStore } from './state';
+
+function makeConfiguration(id: number, name: string): ConfigurationDto {
+  return { id, name, description: '', enabled: true };
+}
+
+describe('useConfigurationStore.setConfiguration', () => {
+  beforeEach(() => {
+    useConfigurationStore.getState().setConfigurations([]);
+  });
+
+  it('inserts an added configuration into its alphabetical position instead of appending it', () => {
+    const { setConfigurations, setConfiguration } = useConfigurationStore.getState();
+
+    setConfigurations([makeConfiguration(1, 'Assistant A'), makeConfiguration(2, 'Assistant C')]);
+    // Duplicating "Assistant A" yields a new configuration named "Assistant B".
+    setConfiguration(makeConfiguration(3, 'Assistant B'));
+
+    const names = useConfigurationStore.getState().configurations.map((c) => c.name);
+    expect(names).toEqual(['Assistant A', 'Assistant B', 'Assistant C']);
+    // Guards against the previous behaviour where the new item was pushed to the end.
+    expect(names[names.length - 1]).not.toBe('Assistant B');
+  });
+
+  it('replaces an existing configuration in place and keeps the list sorted', () => {
+    const { setConfigurations, setConfiguration } = useConfigurationStore.getState();
+
+    setConfigurations([makeConfiguration(1, 'Alpha'), makeConfiguration(2, 'Bravo'), makeConfiguration(3, 'Charlie')]);
+    // Rename "Charlie" (id 3) to "Amber": it must move to its new position, not be appended.
+    setConfiguration(makeConfiguration(3, 'Amber'));
+
+    const configurations = useConfigurationStore.getState().configurations;
+    expect(configurations).toHaveLength(3);
+    expect(configurations.map((c) => c.name)).toEqual(['Alpha', 'Amber', 'Bravo']);
+    expect(configurations.find((c) => c.id === 3)?.name).toEqual('Amber');
+  });
+});


### PR DESCRIPTION
## Problem

In Admin → Assistants, clicking **Duplicate** appends the new assistant to the bottom of the list instead of dropping it into its correct alphabetical position. Reloading the page fixes the order, which points at a client-side state issue rather than the backend.

## Root cause

The backend returns configurations ordered by `name ASC` (see `get-configurations.ts`). On the frontend, the Zustand `setConfiguration` setter in `frontend/src/pages/admin/extensions/state.ts` pushes the new/duplicated configuration onto the array but never re-sorts it, so the local ordering drifts from the backend until the next fetch reloads the sorted list.

## Fix

Re-sort the configurations by `name` (using `localeCompare`) after inserting/updating in the setter, so the in-memory order matches the backend's `name ASC` immediately, without a refresh.

Fixes #414
