### PR TITLE
perf(frontend): reduce long chat rerenders

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,6 +49,11 @@
   overflow-anchor: none;
 }
 
+.chat-history-deferred {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 320px;
+}
+
 @keyframes loading-dot {
   50% {
     opacity: 0.5;

--- a/frontend/src/pages/chat/conversation/ChatHistory.tsx
+++ b/frontend/src/pages/chat/conversation/ChatHistory.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { FileDto } from 'src/api';
 import { useSidebarState } from 'src/hooks/stored';
 import { useStateOfMessages, useStateOfSelectedChatId, useStateOfSelectedDocument } from '../state/chat';
@@ -18,23 +19,28 @@ export function ChatHistory({ agentName, editMessage }: ChatHistoryProps) {
   const [_, setSidebarRight] = useSidebarState('sidebar-right');
 
   const { setSelectedDocument } = useStateOfSelectedDocument();
+  const selectDocument = useCallback(
+    (messageId: number, documentUri: string) => {
+      setSelectedDocument({ conversationId: chatId, messageId, documentUri });
+      setSidebarRight(true);
+    },
+    [chatId, setSelectedDocument, setSidebarRight],
+  );
 
   return (
     <>
       <div className={'grid'}>
         {allMessagesButLastTwo.map((message, i) => (
-          <ChatItem
-            key={`${i}_${chatId}`}
-            agentName={agentName}
-            isLast={i === messages.length - 1}
-            isBeforeLast={i === messages.length - 2}
-            message={message}
-            selectDocument={(documentUri) => {
-              setSelectedDocument({ conversationId: chatId, messageId: message.id, documentUri });
-              setSidebarRight(true);
-            }}
-            editMessage={editMessage}
-          />
+          <div className="chat-history-deferred grid" data-testid="deferred-chat-item" key={`${i}_${chatId}`}>
+            <ChatItem
+              agentName={agentName}
+              isLast={false}
+              isBeforeLast={false}
+              message={message}
+              selectDocument={selectDocument}
+              editMessage={editMessage}
+            />
+          </div>
         ))}
       </div>
       <div className={autoScrollContainerForLastMessageExchange}>
@@ -45,10 +51,7 @@ export function ChatHistory({ agentName, editMessage }: ChatHistoryProps) {
             isLast={i === 1}
             isBeforeLast={i === 0}
             message={message}
-            selectDocument={(documentUri) => {
-              setSelectedDocument({ conversationId: chatId, messageId: message.id, documentUri });
-              setSidebarRight(true);
-            }}
+            selectDocument={selectDocument}
             editMessage={editMessage}
           />
         ))}

--- a/frontend/src/pages/chat/conversation/ChatHistory.ui-unit.spec.tsx
+++ b/frontend/src/pages/chat/conversation/ChatHistory.ui-unit.spec.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '../state/types';
+import { ChatHistory } from './ChatHistory';
+
+const mocks = vi.hoisted(() => ({
+  messages: [] as ChatMessage[],
+  renderMessage: vi.fn(),
+  setSelectedDocument: vi.fn(),
+  setSidebarRight: vi.fn(),
+}));
+
+vi.mock('../state/chat', () => ({
+  useStateOfMessages: () => mocks.messages,
+  useStateOfSelectedChatId: () => 42,
+  useStateOfSelectedDocument: () => ({
+    setSelectedDocument: mocks.setSelectedDocument,
+  }),
+}));
+
+vi.mock('src/hooks/stored', () => ({
+  useSidebarState: () => [false, mocks.setSidebarRight],
+}));
+
+vi.mock('./ChatItem/AIChatItem', () => ({
+  AIChatItem: ({ message }: { message: ChatMessage }) => {
+    mocks.renderMessage(message.id);
+    return <div data-testid="chat-item">{message.id}</div>;
+  },
+}));
+
+vi.mock('./ChatItem/HumanChatItem', () => ({
+  HumanChatItem: ({ message }: { message: ChatMessage }) => {
+    mocks.renderMessage(message.id);
+    return <div data-testid="chat-item">{message.id}</div>;
+  },
+}));
+
+describe('ChatHistory', () => {
+  beforeEach(() => {
+    mocks.messages = [message(1), message(2), message(3), message(4)];
+    mocks.renderMessage.mockClear();
+  });
+
+  it('defers offscreen history and only rerenders changed messages', () => {
+    const editMessage = vi.fn();
+    const { rerender } = render(<ChatHistory agentName="Assistant" editMessage={editMessage} />);
+
+    expect(screen.getAllByTestId('chat-item')).toHaveLength(4);
+    expect(screen.getAllByTestId('deferred-chat-item')).toHaveLength(2);
+
+    mocks.renderMessage.mockClear();
+    mocks.messages = [...mocks.messages.slice(0, -1), message(4, 'updated')];
+    rerender(<ChatHistory agentName="Assistant" editMessage={editMessage} />);
+
+    expect(mocks.renderMessage).toHaveBeenCalledOnce();
+    expect(mocks.renderMessage).toHaveBeenCalledWith(4);
+  });
+});
+
+function message(id: number, text = `message ${id}`): ChatMessage {
+  return {
+    id,
+    type: id % 2 === 0 ? 'ai' : 'human',
+    configurationId: 1,
+    content: [{ type: 'text', text }],
+  };
+}

--- a/frontend/src/pages/chat/conversation/ChatItem/AIChatItem.tsx
+++ b/frontend/src/pages/chat/conversation/ChatItem/AIChatItem.tsx
@@ -62,7 +62,10 @@ export const AIChatItem = ({ agentName, message, isLast, selectDocument }: ChatI
         {textContent}
       </Markdown>
       {message.sources && message.sources?.length > 0 ? (
-        <ChatItemSources sources={message.sources || []} selectDocument={selectDocument} />
+        <ChatItemSources
+          sources={message.sources || []}
+          selectDocument={(documentUri) => selectDocument(message.id, documentUri)}
+        />
       ) : (
         <ChatItemDebug debug={message.debug || []} />
       )}

--- a/frontend/src/pages/chat/conversation/ChatItem/ChatItem.tsx
+++ b/frontend/src/pages/chat/conversation/ChatItem/ChatItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { FileDto, MessageDtoRatingEnum } from 'src/api';
 import { ChatMessage } from '../../state/types';
 import { AIChatItem } from './AIChatItem';
@@ -10,10 +11,10 @@ export interface ChatItemProps {
   isBeforeLast: boolean;
   rating?: MessageDtoRatingEnum;
   llmLogo?: string;
-  selectDocument: (documentUri: string) => void;
+  selectDocument: (messageId: number, documentUri: string) => void;
   editMessage: (input: string, files?: FileDto[], editMessageId?: number) => void;
 }
 
-export const ChatItem = (props: ChatItemProps) => {
+export const ChatItem = memo((props: ChatItemProps) => {
   return props.message.type === 'ai' ? <AIChatItem {...props} /> : <HumanChatItem {...props} />;
-};
+});

--- a/frontend/src/pages/chat/state/chat.ts
+++ b/frontend/src/pages/chat/state/chat.ts
@@ -270,10 +270,7 @@ export const useStateOfMessages = () => {
 };
 
 export const useStateOfIsAiWriting = () => {
-  const currentChatId = useChatStore((s) => s.currentChatId);
-  const chatDataMap = useChatStore((s) => s.chatDataMap);
-  const chatData = chatDataMap.get(currentChatId);
-  return chatData?.isAiWriting || false;
+  return useChatStore((state) => state.chatDataMap.get(state.currentChatId)?.isAiWriting || false);
 };
 
 export const useStateOfSelectedDocument = () => {

--- a/frontend/src/pages/chat/state/chat.ui-unit.spec.tsx
+++ b/frontend/src/pages/chat/state/chat.ui-unit.spec.tsx
@@ -1,0 +1,52 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStateOfIsAiWriting } from './chat';
+import { useChatStore } from './zustand/chatStore';
+
+describe('chat state selectors', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      currentChatId: 0,
+      chatDataMap: new Map(),
+      selectedDocument: undefined,
+      selectedSource: undefined,
+    });
+  });
+
+  it('does not rerender isAiWriting subscribers for message-only updates', () => {
+    act(() => {
+      useChatStore.getState().switchToChat(1);
+      useChatStore.getState().setIsAiWriting(1, true);
+    });
+
+    const renderValue = vi.fn();
+    render(<IsAiWritingSubscriber renderValue={renderValue} />);
+    renderValue.mockClear();
+
+    act(() => {
+      useChatStore.getState().setMessages(1, [
+        {
+          id: 1,
+          type: 'ai',
+          configurationId: 1,
+          content: [{ type: 'text', text: 'updated response' }],
+        },
+      ]);
+    });
+
+    expect(renderValue).not.toHaveBeenCalled();
+
+    act(() => {
+      useChatStore.getState().setIsAiWriting(1, false);
+    });
+
+    expect(renderValue).toHaveBeenCalledOnce();
+    expect(renderValue).toHaveBeenCalledWith(false);
+  });
+});
+
+function IsAiWritingSubscriber({ renderValue }: { renderValue: (value: boolean) => void }) {
+  const isAiWriting = useStateOfIsAiWriting();
+  renderValue(isAiWriting);
+  return null;
+}


### PR DESCRIPTION
## Summary

- defer rendering work for offscreen historical messages while keeping the latest exchange fully rendered for streaming and autoscroll
- memoize chat items and stabilize document-selection callbacks so unchanged messages do not rerender
- subscribe AI-writing consumers to the derived boolean instead of the entire chat map
- add regression tests for historical-message rerenders and message-only store updates

Closes #500

## Validation

- `npm run lint`
- focused Vitest coverage: 4 files, 11 tests passed
- existing ChatInput/Markdown baseline: 9 tests passed
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`
- full frontend suite under Node 24: PR head has 23 failing / 130 passing tests across 9 failing / 23 passing files; a detached clean `origin/main` worktree with the same dependencies reproduces the same 23 failures across the same 9 unrelated admin/login suites, with 128 passing tests across 21 passing files. The two added regression files account for the PR head's additional 2 passing files and 2 passing tests.

The reproduced baseline failures are existing MSW/date-sensitive admin and login test failures, including unmatched mocked requests. No changed chat file appears in the failing set.

## AI assistance

OpenAI Codex was used to investigate, implement, and test this change. The diff and validation output were reviewed before submission.
